### PR TITLE
Update geolib.d.ts

### DIFF
--- a/dist/geolib.d.ts
+++ b/dist/geolib.d.ts
@@ -192,7 +192,7 @@ declare namespace geolib {
      * - in (inch)
      * - yd (yards)
     */
-    function convertUnit(unit: string, distance: number)
+    function convertUnit(unit: string, distance: number): number;
 
 
     /** Converts a given distance (in meters) to another unit. 
@@ -207,7 +207,7 @@ declare namespace geolib {
      * - in (inch)
      * - yd (yards)
     */
-    function convertUnit(unit: string, distance: number, round: number);
+    function convertUnit(unit: string, distance: number, round: number): number;
 
 
     /** Converts a sexagesimal coordinate to decimal format */


### PR DESCRIPTION
Add missing return types to convertUnit() method definitions.

This stops the produced errors on the projects that don't allow "implicit any".